### PR TITLE
Fix for cell style demos

### DIFF
--- a/TablesLists/iOSTableAndCellStyles/Screens/iPhone/CellStyles/TableScreen.cs
+++ b/TablesLists/iOSTableAndCellStyles/Screens/iPhone/CellStyles/TableScreen.cs
@@ -33,8 +33,8 @@ namespace Example_TableAndCellStyles.Screens.iPhone.CellStyles
 		public TableScreen (UITableViewStyle tableStyle, UITableViewCellStyle cellStyle, UITableViewCellAccessory cellAccessory)
 			: base (tableStyle)
 		{
-			cellStyle = cellStyle;
-			cellAccessory = cellAccessory;
+			this.cellStyle = cellStyle;
+			this.cellAccessory = cellAccessory;
 		}
 		
 		#endregion


### PR DESCRIPTION
Cell Style wasn't being set correctly, so each demo was showing the
default cell style instead of subtitle, value1, value2.
