### PR TITLE
Cancel pending intent to avoid Android 4.4 issue

### DIFF
--- a/Notifications/Notifications.Android/MainActivity.cs
+++ b/Notifications/Notifications.Android/MainActivity.cs
@@ -41,7 +41,7 @@
 			stackBuilder.AddParentStack (Class.FromType (typeof(SecondActivity)));
 			stackBuilder.AddNextIntent (resultIntent);
 
-			PendingIntent resultPendingIntent = stackBuilder.GetPendingIntent (0, (int)PendingIntentFlags.UpdateCurrent);
+			PendingIntent resultPendingIntent = stackBuilder.GetPendingIntent (0, (int)PendingIntentFlags.CancelCurrent);
 
 			// Build the notification
 			NotificationCompat.Builder builder = new NotificationCompat.Builder (this)


### PR DESCRIPTION
See http://stackoverflow.com/a/21250686

Without this change, the app will hit a "Permission Denial" error when
it attempts to start the SecondActivity under certain conditions on
Android 4.4.

The "Permission Denial" appears in the `adb logcat` as:

W/ActivityManager( 1275): Permission Denial: starting Intent {
  flg=0x1000c000
  cmp=Notifications.Android/md5ea5d3a24a1582c270a7bc4dbcba32b18.SecondActivity
  bnds=[0,77][480,172] (has extras)
} from null (pid=-1, uid=10059) not exported from uid 10061

This permission problem is caused by the mismatch between "uid=10059" and
"uid 10061". The mismatch can arise if you perform the following steps
on a Google API 19 x86 Android emulator:

1. Run this Notifications sample app.

2. Tap the "Hello World, Click Me!" button.

3. Quit the app.

4. Delete the app from the emulator.

5. Reinstall the app.

6. Again run the app and tap the "Hello World, Click Me!" button.

7. Open the "notifications area", and tap the "Button Clicked"
notification.

The app will _not_ start the SecondActivity.

In this example, the original installation of the sample app at step 1
matches "uid=10059" from the sample error message, while the new
installation at step 5 matches "uid 10061".

The Android OS apparently saves the original "uid" value of 10059
somewhere even after the app has been uninstalled. If you restart the
emulator after step 7, this "saved uid" will be cleared, and the
SecondActivity will start normally.

The behavior is identical if you port the app to Java, so this problem
is not specific to Xamarin.