### PR TITLE
Fix label positions

### DIFF
--- a/LivePlayer/ColorControl/ImageViewController.cs
+++ b/LivePlayer/ColorControl/ImageViewController.cs
@@ -85,10 +85,10 @@ namespace ColorControl {
             //    });
             //};
             //View.Add (saveButton);    
-
-            labelC = new UILabel(new CGRect(10, 160, 90, 20));
+            
+            labelC = new UILabel(new CGRect(10, 240, 90, 20));
             labelS = new UILabel(new CGRect(10, 200, 90, 20));
-            labelB = new UILabel(new CGRect(10, 240, 90, 20));
+            labelB = new UILabel(new CGRect(10, 160, 90, 20));
 
             labelC.Text = "Contrast";
             labelS.Text = "Saturation";


### PR DESCRIPTION
Noticed the label positions for contrast & brightness were swapped. This quick fix puts the label next to the correct slider