### PR TITLE
[XI] fixed build error in the "Touch" project

### DIFF
--- a/Touch/Touch.iOS/Info.plist
+++ b/Touch/Touch.iOS/Info.plist
@@ -26,5 +26,9 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>CFBundleName</key>
+	<string>Touch</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.example_touch</string>
 </dict>
 </plist>

--- a/Touch/Touch.iOS/Touch.iOS.csproj
+++ b/Touch/Touch.iOS/Touch.iOS.csproj
@@ -26,7 +26,7 @@
     <MtouchUseArmv7>false</MtouchUseArmv7>
     <MtouchI18n>
     </MtouchI18n>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <AssemblyName>Touch</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
@@ -41,7 +41,7 @@
     <MtouchSdkVersion>3.2</MtouchSdkVersion>
     <MtouchI18n>
     </MtouchI18n>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <AssemblyName>Touch</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
@@ -59,7 +59,7 @@
     <MtouchSdkVersion>3.2</MtouchSdkVersion>
     <MtouchI18n>
     </MtouchI18n>
-    <MtouchArch>ARMv7</MtouchArch>
+    <MtouchArch>ARMv7s, ARM64</MtouchArch>
     <AssemblyName>Example_Touch</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">


### PR DESCRIPTION
- added missed properties to the `Info.plist` because we started get an error:
```
Info.plist : error : Info.plist does not define CFBundleIdentifier
```
- changed supported arch to be able to run on simulators and devices