### PR TITLE
[XI] fixed the "WeatherApp.iOS" application

### DIFF
--- a/Weather/WeatherApp.iOS/WeatherApp.iOS.csproj
+++ b/Weather/WeatherApp.iOS/WeatherApp.iOS.csproj
@@ -81,6 +81,9 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Entitlements.plist" />

--- a/Weather/WeatherApp/WeatherApp.csproj
+++ b/Weather/WeatherApp/WeatherApp.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We found that iOS app didn't build succeed because of it didn't have an access to the nuget.
 
- re-added nuget in right way
- updated nuget for shared project (there was incompatibility)