### PR TITLE
[XI] removed components - `NotificationHubQuickStart`

### DIFF
--- a/Azure/NotificationHubs/iOS/NotificationHubQuickStart/Info.plist
+++ b/Azure/NotificationHubs/iOS/NotificationHubQuickStart/Info.plist
@@ -32,5 +32,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleName</key>
+	<string>NotificationHubQuickStart</string>
 </dict>
 </plist>

--- a/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj
+++ b/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj
@@ -27,6 +27,8 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>full</DebugType>
@@ -38,6 +40,8 @@
     <ConsolePause>false</ConsolePause>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -77,10 +81,10 @@
     <ConsolePause>false</ConsolePause>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <BuildIpa>true</BuildIpa>
-    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>full</DebugType>
@@ -91,9 +95,9 @@
     <CodesignKey>iPhone Distribution</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <ConsolePause>false</ConsolePause>
-    <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <CodesignProvision>Automatic:AppStore</CodesignProvision>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -101,16 +105,11 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\Components\azure-mobile-services-1.3.1\lib\ios-unified\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\Components\azure-mobile-services-1.3.1\lib\ios-unified\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\Components\azure-mobile-services-1.3.1\lib\ios-unified\System.Net.Http.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Messaging.iOS">
-      <HintPath>..\Components\azure-messaging-1.1.5.3\lib\ios-unified\Microsoft.WindowsAzure.Messaging.iOS.dll</HintPath>
+    <Reference Include="Xamarin.Azure.NotificationHubs.iOS">
+      <HintPath>..\packages\Xamarin.Azure.NotificationHubs.iOS.1.2.5.2\lib\Xamarin.iOS10\Xamarin.Azure.NotificationHubs.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -119,6 +118,7 @@
   <ItemGroup>
     <None Include="Info.plist" />
     <None Include="Entitlements.plist" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />

--- a/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj
+++ b/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj
@@ -104,10 +104,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Xamarin.Azure.NotificationHubs.iOS">
       <HintPath>..\packages\Xamarin.Azure.NotificationHubs.iOS.1.2.5.2\lib\Xamarin.iOS10\Xamarin.Azure.NotificationHubs.iOS.dll</HintPath>
     </Reference>

--- a/Azure/NotificationHubs/iOS/NotificationHubQuickStart/packages.config
+++ b/Azure/NotificationHubs/iOS/NotificationHubQuickStart/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="xamarinios10" />
   <package id="Xamarin.Azure.NotificationHubs.iOS" version="1.2.5.2" targetFramework="xamarinios10" />
 </packages>

--- a/Azure/NotificationHubs/iOS/NotificationHubQuickStart/packages.config
+++ b/Azure/NotificationHubs/iOS/NotificationHubQuickStart/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="xamarinios10" />
+  <package id="Xamarin.Azure.NotificationHubs.iOS" version="1.2.5.2" targetFramework="xamarinios10" />
+</packages>


### PR DESCRIPTION
Test Reports: http://xqa.blob.core.windows.net/gist/report-9e33c5195c994c21b20b041c8a018b53.txt
```
"/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj" (Build target) (1) ->
(ResolveAssemblyReferences target) -> 
  /Library/Frameworks/Mono.framework/Versions/5.10.1/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2067,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "Newtonsoft.Json". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj]
  /Library/Frameworks/Mono.framework/Versions/5.10.1/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2067,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Net.Http.Extensions". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj]
  /Library/Frameworks/Mono.framework/Versions/5.10.1/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2067,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Net.Http.Primitives". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj]
  /Library/Frameworks/Mono.framework/Versions/5.10.1/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2067,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "Microsoft.WindowsAzure.Messaging.iOS". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj]


"/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj" (Build target) (1) ->
(CoreCompile target) -> 
  AppDelegate.cs(6,7): error CS0246: The type or namespace name 'WindowsAzure' could not be found (are you missing a using directive or an assembly reference?) [/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj]
  AppDelegate.cs(16,17): error CS0246: The type or namespace name 'SBNotificationHub' could not be found (are you missing a using directive or an assembly reference?) [/Users/xamarinqa/myagent/_work/r14/a/mobile-samples/Azure/NotificationHubs/iOS/NotificationHubQuickStart/NotificationHubQuickStart.csproj]

```