### PR TITLE
Changed api versions to remove popup with warning on Android P

### DIFF
--- a/Tasky/TaskyAndroid/Properties/AndroidManifest.xml
+++ b/Tasky/TaskyAndroid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.0" package="com.xamarin.samples.taskyandroid" android:versionCode="2">
 	<application android:label="Tasky" android:debuggable="true" android:icon="@drawable/icon" android:theme="@style/Theme.Tasky"></application>
-	<uses-sdk android:minSdkVersion="15" />
+	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="25" />
 </manifest>

--- a/Tasky/TaskyAndroid/TaskyAndroid.csproj
+++ b/Tasky/TaskyAndroid/TaskyAndroid.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AssemblyName>TaskyAndroid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
   </PropertyGroup>


### PR DESCRIPTION
This commit removes popup on Android P "This app was build for an older version of Android and may not work properly. Try checking for updates, or contact the developer." 