### PR TITLE
Inhibit Android Q "app needs upgrade" dialog and support running against all devices in Test Cloud

### DIFF
--- a/Tasky/TaskyAndroid/Properties/AndroidManifest.xml
+++ b/Tasky/TaskyAndroid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.0" package="com.xamarin.samples.taskyandroid" android:versionCode="2">
 	<application android:label="Tasky" android:debuggable="true" android:icon="@drawable/icon" android:theme="@style/Theme.Tasky"></application>
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="23" />
+	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="23" />
 </manifest>

--- a/Tasky/TaskyAndroid/Properties/AndroidManifest.xml
+++ b/Tasky/TaskyAndroid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.0" package="com.xamarin.samples.taskyandroid" android:versionCode="2">
 	<application android:label="Tasky" android:debuggable="true" android:icon="@drawable/icon" android:theme="@style/Theme.Tasky"></application>
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="25" />
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="23" />
 </manifest>


### PR DESCRIPTION
### Description of Change

Progress on:

* Xamarin.UITest: move sources for Android test apps from test-cloud-test-apps and migrate integration tests away from rake binaries:{push|fetch} model [ADO](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/63758)
* Test UITest locally on Android Q devices and simulator [ADO](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/62111)

<!-- Notes:
Do not update the Xamarin.Forms NuGet packages, or Android support libraries.
Do not use pre-release versions of NuGet packages.
If you update a NuGet package in a project, please ensure that you update the same package in the other projects in the sample (if present).
If you change code in the library project in a sample, please ensure that you thoroughly test the changes on all platforms.
If you change code in a platform project in a sample, please ensure that you thoroughly test the change on the platform.
-->

### Pull Request Checklist

<!-- Please complete -->

- [ ] Rebased on top of master at time of the pull request.
- [ ] Changes adhere to coding standard in the sample.
- [ ] Consolidated NuGet packages across all projects in the sample (when changing existing package versions).
- [ ] Tested changes on the appropriate platforms (all platforms if changing the library code).